### PR TITLE
Improved system for saving player settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
+/server/
 DurabilityAlert.iml
+dependency-reduced-pom.xml
+/target/

--- a/src/main/java/me/darkolythe/durabilityalert/CommandHandler.java
+++ b/src/main/java/me/darkolythe/durabilityalert/CommandHandler.java
@@ -26,7 +26,7 @@ public class CommandHandler implements CommandExecutor {
                             } else {
                                 player.sendMessage(main.prefix + ChatColor.GREEN + main.confighandler.warningsenabled);
                             }
-                            main.joinlistener.playerSave(player);
+                            PlayerSaveManager.save(player);
                         } else if (args[0].equalsIgnoreCase("status")) {
                             Utility.printStatus(player, main);
                         } else if (args[0].equalsIgnoreCase("type")) {
@@ -38,7 +38,7 @@ public class CommandHandler implements CommandExecutor {
                             } else {
                                 player.sendMessage(main.prefix + ChatColor.GREEN + main.confighandler.enchantedtrue);
                             }
-                            main.joinlistener.playerSave(player);
+                            PlayerSaveManager.save(player);
                         } else {
                             player.sendMessage(main.prefix + ChatColor.RED + main.confighandler.invalidarguments + ": /durabilityalert [toggle/armour/tools/type/status/enchant]");
                         }
@@ -47,7 +47,7 @@ public class CommandHandler implements CommandExecutor {
                             if (args[1].equalsIgnoreCase("durability") || args[1].equalsIgnoreCase("percent")) {
                                 main.setPlayerType(player, (args[1].equalsIgnoreCase("durability") ? 1 : 0));
                                 player.sendMessage(main.prefix + ChatColor.GREEN + main.confighandler.settype.replaceAll("%type%", args[1]));
-                                main.joinlistener.playerSave(player);
+                                PlayerSaveManager.save(player);
                             } else {
                                 player.sendMessage(main.prefix + ChatColor.RED + main.confighandler.invalidarguments + ": /durabilityalert type [percent/durability]");
                             }
@@ -58,11 +58,11 @@ public class CommandHandler implements CommandExecutor {
                             if (args[0].equalsIgnoreCase("armour") || args[0].equalsIgnoreCase("armor") || args[0].equalsIgnoreCase("a")) {
                                 main.setPlayerArmour(player, percent);
                                 player.sendMessage(main.prefix + ChatColor.GREEN + main.confighandler.armourset.replaceAll("%armour%", Integer.toString(percent)));
-                                main.joinlistener.playerSave(player);
+                                PlayerSaveManager.save(player);
                             } else if (args[0].equalsIgnoreCase("tools") || args[0].equalsIgnoreCase("tool") || args[0].equalsIgnoreCase("t")) {
                                 main.setPlayerTools(player, percent);
                                 player.sendMessage(main.prefix + ChatColor.GREEN + main.confighandler.toolset.replaceAll("%tool%", Integer.toString(percent)));
-                                main.joinlistener.playerSave(player);
+                                PlayerSaveManager.save(player);
                             } else {
                                 player.sendMessage(main.prefix + ChatColor.RED + main.confighandler.invalidarguments + ": /durabilityalert [armour/tools]");
                             }

--- a/src/main/java/me/darkolythe/durabilityalert/DurabilityAlert.java
+++ b/src/main/java/me/darkolythe/durabilityalert/DurabilityAlert.java
@@ -1,6 +1,7 @@
 package me.darkolythe.durabilityalert;
 
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -30,10 +31,9 @@ public final class DurabilityAlert extends JavaPlugin {
 
         saveDefaultConfig();
 
-        joinlistener = new JoinListener(plugin);
+        joinlistener = new JoinListener();
         durabilitylistener = new DurabilityListener(plugin);
         confighandler = new ConfigHandler(plugin);
-        joinlistener.setup();
 
         // register events
         getServer().getPluginManager().registerEvents(durabilitylistener, plugin);
@@ -61,7 +61,11 @@ public final class DurabilityAlert extends JavaPlugin {
 
         Metrics metrics = new Metrics(plugin);
 
-        joinlistener.onServerStart();
+        PlayerSaveManager.convertOldFile();
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            PlayerSaveManager.load(p);
+        }
 
         displaytime = getConfig().getInt("displaytime");
         defaultvalue = getConfig().getInt("defaultvalue");
@@ -72,11 +76,6 @@ public final class DurabilityAlert extends JavaPlugin {
         prefix = ChatColor.translateAlternateColorCodes('&', getConfig().getString("prefix"));
 
         System.out.println(prefix + ChatColor.GREEN + "DurabilityAlert enabled!");
-    }
-
-    @Override
-    public void onDisable() {
-        joinlistener.onServerStop();
     }
 
     public static DurabilityAlert getInstance() {

--- a/src/main/java/me/darkolythe/durabilityalert/JoinListener.java
+++ b/src/main/java/me/darkolythe/durabilityalert/JoinListener.java
@@ -1,92 +1,19 @@
 package me.darkolythe.durabilityalert;
 
-import net.md_5.bungee.api.ChatColor;
-import org.bukkit.Bukkit;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
 public class JoinListener implements Listener {
-
-    private DurabilityAlert plugin = DurabilityAlert.getInstance();
-
-    private FileConfiguration playerDataConfig;
-    private File playerData;
-
-    private DurabilityAlert main;
-    JoinListener(DurabilityAlert plugin) {
-        main = plugin;
-    }
-
-    void setup() {
-        if (!plugin.getDataFolder().exists()) {
-            plugin.getDataFolder().mkdir();
-        }
-
-        playerData = new File(plugin.getDataFolder(), "PlayerData.yml");
-
-        if (!playerData.exists()) {
-            try {
-                playerData.createNewFile();
-                System.out.println(main.prefix + ChatColor.GREEN + "PlayerData.yml has been created");
-            } catch (IOException e) {
-                System.out.println(main.prefix + ChatColor.RED + "Could not create PlayerData.yml");
-            }
-        }
-        playerDataConfig = YamlConfiguration.loadConfiguration(playerData);
-    }
 
     @EventHandler
     private void onPlayerJoin(PlayerJoinEvent event) {
-        playerLoad(event.getPlayer());
+        PlayerSaveManager.load(event.getPlayer());
     }
-
     @EventHandler
     private void onPlayerLeave(PlayerQuitEvent event) {
-        playerSave(event.getPlayer());
-        main.removePlayerData(event.getPlayer());
-    }
-
-    public void onServerStop() {
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            playerSave(p);
-        }
-    }
-
-    public void onServerStart() {
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            playerLoad(p);
-        }
-    }
-
-    private void playerLoad(Player player) {
-        if (playerDataConfig.contains("player." + player.getUniqueId())) {
-            List<Integer> data = playerDataConfig.getIntegerList("player." + player.getUniqueId());
-            if (data.size() < 4) {
-                data.add(0);
-            }
-            main.setPlayerData(player, data);
-        }
-    }
-
-    void playerSave(Player player) {
-        playerDataConfig = YamlConfiguration.loadConfiguration(playerData);
-
-        String path = "player." + player.getUniqueId();
-        playerDataConfig.set(path, main.getPlayerData(player));
-
-        try {
-            playerDataConfig.save(playerData);
-        } catch (IOException e) {
-            System.out.println(main.prefix + ChatColor.RED + "Could not save recipes");
-        }
+        PlayerSaveManager.remove(event.getPlayer());
+        DurabilityAlert.getInstance().removePlayerData(event.getPlayer());
     }
 }

--- a/src/main/java/me/darkolythe/durabilityalert/PlayerSaveManager.java
+++ b/src/main/java/me/darkolythe/durabilityalert/PlayerSaveManager.java
@@ -1,0 +1,100 @@
+package me.darkolythe.durabilityalert;
+
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+public abstract class PlayerSaveManager
+{
+    private static final File playersDirectory;
+    private static HashMap<Player, FileConfiguration> playersData = new HashMap<>();
+
+    static
+    {
+        playersDirectory = new File(DurabilityAlert.getInstance().getDataFolder(), "players/");
+        if(!playersDirectory.exists())
+        {
+            playersDirectory.mkdir();
+        }
+    }
+
+    public static void convertOldFile()
+    {
+        File oldPlayerDataFile = new File(DurabilityAlert.getInstance().getDataFolder(), "PlayerData.yml");
+
+        if(oldPlayerDataFile.exists())
+        {
+            FileConfiguration oldDatas = YamlConfiguration.loadConfiguration(oldPlayerDataFile);
+
+            for(String uuid: oldDatas.getConfigurationSection("player").getKeys(false))
+            {
+                File playerFile = new File(playersDirectory, uuid+".yml");
+
+                try {
+                    FileConfiguration playerDatas = YamlConfiguration.loadConfiguration(playerFile);
+                    playerDatas.set("data", oldDatas.getIntegerList("player."+uuid));
+                    playerDatas.save(playerFile);
+                } catch (IOException e) {
+                    System.out.println(DurabilityAlert.getInstance().prefix + ChatColor.RED + "Could not save recipes");
+                }
+            }
+
+            oldPlayerDataFile.renameTo(new File(DurabilityAlert.getInstance().getDataFolder(), "PlayerData.yml.old"));
+            DurabilityAlert.getInstance().getLogger().info("Old PlayerData file converted");
+        }
+    }
+
+    public static void load(Player player)
+    {
+        File playerFile = new File(playersDirectory, player.getUniqueId()+".yml");
+        if(playerFile.exists())
+        {
+            FileConfiguration playerDatas = YamlConfiguration.loadConfiguration(playerFile);
+            playersData.put(player, playerDatas);
+            List<Integer> data = playerDatas.getIntegerList("data");
+            if (data.size() < 4) {
+                data.add(0);
+            }
+            DurabilityAlert.getInstance().setPlayerData(player, data);
+        }
+    }
+
+    public static void save(Player player)
+    {
+        File playerFile = new File(playersDirectory, player.getUniqueId()+".yml");
+
+        if(!playersData.containsKey(player))
+        {
+            if(!playersDirectory.exists())
+            {
+                playersDirectory.mkdir();
+            }
+
+            try {
+                playerFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            playersData.put(player, YamlConfiguration.loadConfiguration(playerFile));
+        }
+
+        try {
+            FileConfiguration playerDatas = playersData.get(player);
+            playerDatas.set("data", DurabilityAlert.getInstance().getPlayerData(player));
+            playerDatas.save(playerFile);
+        } catch (IOException e) {
+            System.out.println(DurabilityAlert.getInstance().prefix + ChatColor.RED + "Could not save recipes");
+        }
+    }
+
+    public static void remove(Player player)
+    {
+        playersData.remove(player);
+    }
+}


### PR DESCRIPTION
Hello,
I created this version because saving all players in the same file is very heavy when you have many unique players on the server. This causes slowdowns (increased mspt) when loading and saving players, which often happened with the save on logout.
In this version the player information is saved in one file per player. This creates more files but they are smaller and therefore easier to edit when saving.
The player's settings are only saved when he changes one of his settings.

To avoid problems with older versions of the plugin, the version includes an automatic migration system from the old storage system to the new one.

If you have any questions, don't hesitate!